### PR TITLE
Fix OTP length mismatch by passing generated OTP to SMS sender

### DIFF
--- a/backend/src/controllers/user.controllers.js
+++ b/backend/src/controllers/user.controllers.js
@@ -48,7 +48,7 @@ export const registerUser = asyncHandler(async (req, res)=>{
 
  const otp =  Math.floor(1000 + Math.random() * 9000).toString(); 
 
-  const result = await sendingSms(phoneNumber );
+  const result = await sendingSms(phoneNumber ,otp);
   //console.log("informaton about the sending sms" ,result)
   if(result.success===false)
   {


### PR DESCRIPTION
### What was wrong
OTP was generated in the controller but not passed to the SMS sender, causing `undefined` OTP and API errors.

### What this PR does
- Passes the generated OTP from the controller to `sendOtp()`
- Ensures the SMS API receives a valid 4-digit OTP

### Result
Fixes the "Invalid OTP Code - Length Mismatch" error during user registration.
